### PR TITLE
DatabaseConfigが保存されない不具合を反映

### DIFF
--- a/Editor/DatabaseConfigEditor.cs
+++ b/Editor/DatabaseConfigEditor.cs
@@ -13,6 +13,7 @@ namespace Natto.Editor
             var config = target as DatabaseConfig;
             config.databaseType = (DatabaseType)EditorGUILayout.EnumPopup ("Database Type", config.databaseType);
             ShowDatabaseConfigField (config);
+            EditorUtility.SetDirty(config);
         }
 
         private void ShowDatabaseConfigField (DatabaseConfig config)


### PR DESCRIPTION
#14 
4.5以前は `EditorUtility.SetDirty` なくても動作したが、それ以降で変更を明示的に通知しないといけなくなったみたい。